### PR TITLE
Add support for Astro v2

### DIFF
--- a/.changeset/silver-jokes-confess.md
+++ b/.changeset/silver-jokes-confess.md
@@ -1,0 +1,5 @@
+---
+'astro-auto-import': patch
+---
+
+Allow installation in Astro v2 projects

--- a/package-lock.json
+++ b/package-lock.json
@@ -9043,7 +9043,7 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "astro": "^1.0.0"
+        "astro": "^1.0.0 || ^2.0.0-beta"
       }
     },
     "packages/astro-auto-import/node_modules/@types/node": {

--- a/packages/astro-auto-import/package.json
+++ b/packages/astro-auto-import/package.json
@@ -38,7 +38,7 @@
     "acorn": "^8.8.0"
   },
   "peerDependencies": {
-    "astro": "^1.0.0"
+    "astro": "^1.0.0 || ^2.0.0-beta"
   },
   "engines": {
     "node": ">=16.0.0"


### PR DESCRIPTION
Updates `package.json` to allow Astro v2 (incl beta) as peer dependency.

Manually tested install and that imports work in a Astro v2.0.0-beta.2 project.

Fix #10 