### PR TITLE
refactor: strip out old “exposures” code

### DIFF
--- a/.changeset/early-moles-arrive.md
+++ b/.changeset/early-moles-arrive.md
@@ -1,0 +1,5 @@
+---
+"astro-auto-import": patch
+---
+
+refactor: strip out old “exposures” code


### PR DESCRIPTION
An old version of this package used code to attach auto-imports to `globalThis` (for Asto-flavored Markdown support). This has been unused for quite a while but was still hanging around making code look more complicated than it needed to be. This PR deletes all that old pointless code 🎉 