### PR TITLE
Allows astro-auto-import to be installed in projects developed with Astro v5

### DIFF
--- a/.changeset/light-pillows-know.md
+++ b/.changeset/light-pillows-know.md
@@ -1,0 +1,5 @@
+---
+"astro-auto-import": patch
+---
+
+Adds support for Astro v5

--- a/packages/astro-auto-import/package.json
+++ b/packages/astro-auto-import/package.json
@@ -39,7 +39,7 @@
     "acorn": "^8.8.0"
   },
   "peerDependencies": {
-    "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta"
+    "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta"
   },
   "engines": {
     "node": ">=16.0.0"


### PR DESCRIPTION
- Add ^5.0.0-beta to package.json.

Allows `astro-auto-import` to be installed in projects developed with Astro v5