### PR TITLE
Test Astro v5 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Setup Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: ${{ matrix.node }}
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         node: [18.x]
         os: [ubuntu-latest, windows-latest]
-        astro: [^2, ^3, ^4]
+        astro: [^2, ^3, ^4, ^5]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -38,7 +38,7 @@ jobs:
         working-directory: packages/astro-auto-import
       - run: npm i astro@${{ matrix.astro }} @astrojs/mdx@${{ env.MDX_VERSION }}
         env:
-          MDX_VERSION: ${{ matrix.astro == '^2' && '0.19.7' || matrix.astro == '^3' && '^1' || '^2' }}
+          MDX_VERSION: ${{ matrix.astro == '^2' && '0.19.7' || matrix.astro == '^3' && '^1' || matrix.astro == '^4' && '^3' || '^4' }}
         working-directory: demo
 
       - name: Test


### PR DESCRIPTION
This PR updates CI tests to also run using Astro v5 + `@astrojs/mdx` v4.

It also updates and pins the checkout and Node setup actions using SHAs.