### PR TITLE
Use shared Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,24 +1,4 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": [
-		"config:recommended",
-		":disableDependencyDashboard",
-		":disablePeerDependencies",
-		"helpers:pinGitHubActionDigestsToSemver"
-	],
-	"rangeStrategy": "bump",
-	"ignorePaths": ["**/node_modules/**"],
-	"minimumReleaseAge": "3 days",
-	"postUpdateOptions": ["pnpmDedupe"],
-	"packageRules": [
-		{
-			"groupName": "github-actions",
-			"matchManagers": ["github-actions"]
-		},
-		{
-			"groupName": "astro",
-			"matchDatasources": ["npm"],
-			"matchPackageNames": ["astro", "@astrojs/**"]
-		}
-	]
+	"extends": ["local>delucis/renovate-config"]
 }


### PR DESCRIPTION
Updates the Renovate config to use the shared one in https://github.com/delucis/renovate-config