### PR TITLE
feat: Enable overriding of MDX components

### DIFF
--- a/.changeset/chatty-moles-laugh.md
+++ b/.changeset/chatty-moles-laugh.md
@@ -1,0 +1,6 @@
+---
+"astro-auto-import": patch
+"@demo/astro-auto-import": patch
+---
+
+feat: Enable overriding of default MDX components

--- a/demo/astro.config.mjs
+++ b/demo/astro.config.mjs
@@ -17,6 +17,9 @@ export default defineConfig({
           './src/components/barrel.ts': 'Barrel',
         },
       ],
+      defaultComponents: {
+        p: './src/components/CustomParagraph.astro',
+      },
     }),
     mdx(),
   ],

--- a/demo/src/components/CustomLink.astro
+++ b/demo/src/components/CustomLink.astro
@@ -1,0 +1,7 @@
+---
+interface Props {
+  href?: string;
+}
+const { href } = Astro.props;
+---
+<a href={href} class="custom-link"><slot /></a>

--- a/demo/src/components/CustomParagraph.astro
+++ b/demo/src/components/CustomParagraph.astro
@@ -1,0 +1,3 @@
+---
+---
+<p class="custom-paragraph"><slot /></p>

--- a/demo/src/pages/custom-components.mdx
+++ b/demo/src/pages/custom-components.mdx
@@ -1,0 +1,16 @@
+---
+layout: ../layouts/Layout.astro
+---
+import CustomLink from '../components/CustomLink.astro';
+
+export const components = {
+  a: CustomLink,
+};
+
+# Page with custom components export
+
+This page defines its own `components` export, so the auto-import defaultComponents should be skipped.
+
+This paragraph should NOT have the custom-paragraph class.
+
+[This link](/nested) should have the custom-link class from the local export.

--- a/packages/astro-auto-import/README.md
+++ b/packages/astro-auto-import/README.md
@@ -142,6 +142,53 @@ This config would import all the components in an index file, making them availa
 import * as Components from './src/components/index';
 ```
 
+#### `defaultComponents`
+
+**Type**: `Record<string, string | { name: string; from: string }>`
+
+A map of HTML element names to components that should override them in MDX. This allows you to replace default HTML elements like `<p>`, `<a>`, `<h1>`, etc. with custom components.
+
+> **Note:** Due to [a bug in @astrojs/mdx](https://github.com/withastro/astro/issues/14611), this feature requires `optimize: false` (the default). Starlight enables optimization by default, so you'll need to explicitly disable it:
+>
+> ```js
+> mdx({ optimize: false })
+> ```
+
+If an MDX file already exports its own `components` object, the auto-imported `defaultComponents` will be skipped to avoid conflicts.
+
+```js
+AutoImport({
+  imports: [
+    // ... your imports
+  ],
+  defaultComponents: {
+    // Use a default export from a file
+    // generates:
+    // import AUTO_IMPORT_p from './src/components/CustomParagraph.astro';
+    p: './src/components/CustomParagraph.astro',
+
+    // Use a named export from a file
+    // generates:
+    // import { CustomBlockquote as AUTO_IMPORT_blockquote } from './src/components/Components.ts';
+    blockquote: { name: 'CustomBlockquote', from: './src/components/Components.ts' },
+  },
+});
+```
+
+This will generate the necessary imports and export a `components` object that MDX uses to override default HTML elements:
+
+##### Equivalent to
+
+```js
+import AUTO_IMPORT_p from './src/components/CustomParagraph.astro';
+import { CustomBlockquote as AUTO_IMPORT_blockquote } from './src/components/Components.ts';
+
+export const components = {
+  p: AUTO_IMPORT_p,
+  blockquote: AUTO_IMPORT_blockquote,
+};
+```
+
 ## License
 
 MIT

--- a/packages/astro-auto-import/src/index.ts
+++ b/packages/astro-auto-import/src/index.ts
@@ -14,8 +14,18 @@ const resolveModulePath = (path: string) => {
 type NamedImportConfig = string | [from: string, as: string];
 type ImportsConfig = (string | Record<string, string | NamedImportConfig[]>)[];
 
+/** Config for a named export from a module */
+interface NamedExportConfig {
+  name: string;
+  from: string;
+}
+
+/** Map of element names to component paths or named export configs */
+type DefaultComponentsConfig = Record<string, string | NamedExportConfig>;
+
 interface AutoImportConfig {
-  imports: ImportsConfig;
+  imports?: ImportsConfig;
+  defaultComponents?: DefaultComponentsConfig;
 }
 
 /**
@@ -72,10 +82,42 @@ function processImportsConfig(config: ImportsConfig) {
   return imports;
 }
 
-/** Get an MDX node representing a block of imports based on user config. */
-function generateImportsNode(config: ImportsConfig): MdxjsEsm {
-  const imports = processImportsConfig(config);
-  const js = imports.join('\n');
+/** Prefix used for default component imports to avoid name clashes */
+const DEFAULT_COMPONENT_PREFIX = 'AUTO_IMPORT_';
+
+/** Generate imports and export statement for default components config. */
+function processDefaultComponentsConfig(config: DefaultComponentsConfig) {
+  const imports: string[] = [];
+  const componentEntries: string[] = [];
+
+  for (const elementName in config) {
+    const componentConfig = config[elementName];
+    const importName = `${DEFAULT_COMPONENT_PREFIX}${elementName}`;
+
+    if (typeof componentConfig === 'string') {
+      // Default export: import AUTO_IMPORT_p from './src/CustomParagraph.astro';
+      imports.push(formatImport(importName, resolveModulePath(componentConfig)));
+    } else {
+      // Named export: import { CustomBlockquote as AUTO_IMPORT_blockquote } from './src/Components.ts';
+      imports.push(
+        formatImport(
+          `{ ${componentConfig.name} as ${importName} }`,
+          resolveModulePath(componentConfig.from)
+        )
+      );
+    }
+
+    componentEntries.push(`${elementName}: ${importName}`);
+  }
+
+  // Generate: export const components = { p: AUTO_IMPORT_p, blockquote: AUTO_IMPORT_blockquote };
+  const exportStatement = `export const components = { ${componentEntries.join(', ')} };`;
+
+  return { imports, exportStatement };
+}
+
+/** Get an MDX node representing a block of JS (imports and/or exports) based on user config. */
+function generateMdxEsmNode(js: string): MdxjsEsm {
   return {
     type: 'mdxjsEsm',
     value: '',
@@ -89,6 +131,52 @@ function generateImportsNode(config: ImportsConfig): MdxjsEsm {
       },
     },
   };
+}
+
+/** Get an MDX node representing a block of imports based on user config. */
+function generateImportsNode(config: ImportsConfig): MdxjsEsm {
+  const imports = processImportsConfig(config);
+  const js = imports.join('\n');
+  return generateMdxEsmNode(js);
+}
+
+/** Get an MDX node representing imports and export for default components. */
+function generateDefaultComponentsNode(config: DefaultComponentsConfig): MdxjsEsm {
+  const { imports, exportStatement } = processDefaultComponentsConfig(config);
+  const js = [...imports, exportStatement].join('\n');
+  return generateMdxEsmNode(js);
+}
+
+/** Check if the tree already has an `export const components` or `export { components }` */
+function hasComponentsExport(tree: { children: any[] }): boolean {
+  for (const node of tree.children) {
+    if (node.type !== 'mdxjsEsm') continue;
+    const estree = node.data?.estree;
+    if (!estree?.body) continue;
+
+    for (const statement of estree.body) {
+      // Check for: export const components = ...
+      if (
+        statement.type === 'ExportNamedDeclaration' &&
+        statement.declaration?.type === 'VariableDeclaration'
+      ) {
+        for (const decl of statement.declaration.declarations) {
+          if (decl.id?.name === 'components') {
+            return true;
+          }
+        }
+      }
+      // Check for: export { components } or export { something as components }
+      if (statement.type === 'ExportNamedDeclaration' && statement.specifiers) {
+        for (const spec of statement.specifiers) {
+          if (spec.exported?.name === 'components') {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
 }
 
 export default function AutoImport(integrationConfig: AutoImportConfig): AstroIntegration {
@@ -110,15 +198,38 @@ export default function AutoImport(integrationConfig: AutoImportConfig): AstroIn
         // Skip adding MDX plug-in if MDX is not being used.
         if (mdxIndex === -1) return;
 
+        // Pre-generate nodes
+        const importsNode = integrationConfig.imports
+          ? generateImportsNode(integrationConfig.imports)
+          : null;
+        const defaultComponentsNode = integrationConfig.defaultComponents
+          ? generateDefaultComponentsNode(integrationConfig.defaultComponents)
+          : null;
+
+        // Skip if nothing to inject
+        if (!importsNode && !defaultComponentsNode) return;
+
         // Add a remark plugin to inject imports into `.mdx`.
-        const importsNode = generateImportsNode(integrationConfig.imports);
         updateConfig({
           markdown: {
             remarkPlugins: [
               function rehypeInjectMdxImports() {
                 return function injectMdxImports(tree: { children: any[] }, vfile: VFile) {
-                  if (!vfile.basename?.endsWith('.md')) {
-                    tree.children.unshift(importsNode);
+                  if (vfile.basename?.endsWith('.md')) return;
+
+                  const nodesToInject: MdxjsEsm[] = [];
+
+                  if (importsNode) {
+                    nodesToInject.push(importsNode);
+                  }
+
+                  // Only inject defaultComponents if the file doesn't already export components
+                  if (defaultComponentsNode && !hasComponentsExport(tree)) {
+                    nodesToInject.push(defaultComponentsNode);
+                  }
+
+                  if (nodesToInject.length > 0) {
+                    tree.children.unshift(...nodesToInject);
                   }
                 };
               },

--- a/test/astro-auto-import.ts
+++ b/test/astro-auto-import.ts
@@ -28,4 +28,18 @@ test('it should render components imported from a barrel module', () => {
   checkPage(loadPage('/barrel'));
 });
 
+test('it should override default HTML elements with defaultComponents', () => {
+  const page = loadPage('/');
+  // Check that paragraphs use the custom-paragraph class from CustomParagraph.astro
+  assert.match(page, /class="custom-paragraph"/);
+});
+
+test('it should skip defaultComponents when file has its own components export', () => {
+  const page = loadPage('/custom-components');
+  // The page defines its own components export with a custom link
+  assert.match(page, /class="custom-link"/);
+  // The auto-imported defaultComponents (custom-paragraph) should NOT be applied
+  assert.not.match(page, /class="custom-paragraph"/);
+});
+
 test.run();


### PR DESCRIPTION
Per #30 (and following the suggested [design in this comment](https://github.com/delucis/astro-auto-import/issues/30#issuecomment-1921726627)), add the ability to override components in MDX files without explicitly needing to define the overrides in an MDX file.

This is skipped if it's detected that we already have an exported components object

Tested with a local starlight project, which is where I realized that optimizations need to be turned off for this to work right now, due to withastro/astro/issues/14611

Example usage:

```ts
AutoImport({
    imports: [
      {
        '@astrojs/starlight/components': [
          ['TabItem', 'Tab']
        ],
      },
    ],
    defaultComponents: {
      a: './src/components/AOverride.astro'
    }
  })
]
```