### PR TITLE
Fix Astro & MDX version matrixes in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [24.x]
         os: [ubuntu-latest, windows-latest]
         astro: [^5, alpha]
     runs-on: ${{ matrix.os }}
@@ -30,10 +29,10 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
 
-      - name: Setup Node.js ${{ matrix.node }}
+      - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 24.13.0
           cache: pnpm
 
       - name: Install Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        astro: [^5, alpha]
+        astro: [^5, ^6]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -43,7 +43,7 @@ jobs:
         working-directory: packages/astro-auto-import
       - run: pnpm i astro@${{ matrix.astro }} @astrojs/mdx@${{ env.MDX_VERSION }}
         env:
-          MDX_VERSION: ${{ matrix.astro == '^5' && '^4' || 'alpha' }}
+          MDX_VERSION: ${{ matrix.astro == '^5' && '^4' || '^6' }}
         working-directory: demo
 
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         working-directory: packages/astro-auto-import
       - run: pnpm i astro@${{ matrix.astro }} @astrojs/mdx@${{ env.MDX_VERSION }}
         env:
-          MDX_VERSION: ${{ matrix.astro == '^5' && '^4' || '^6' }}
+          MDX_VERSION: ${{ matrix.astro == '^5' && '^4' || '^5' }}
         working-directory: demo
 
       - name: Test


### PR DESCRIPTION
- Updates CI to test Astro v5 and v6 — CI was failing due to testing the Astro `alpha` tag, which now resolves to the v7 alpha
- Updates the version of Node used in CI to v24 latest