### PR TITLE
Add support for the Sätteri Markdown processor

### DIFF
--- a/.changeset/satteri-support.md
+++ b/.changeset/satteri-support.md
@@ -2,4 +2,4 @@
 'astro-auto-import': minor
 ---
 
-Adds support for the Sätteri Markdown processor, which is Astro 7’s default. Auto imports now work with both `satteri()` and `unified()` without any config change.
+Adds support for the Sätteri Markdown processor, which is Astro 7’s default. Auto imports now work with both `satteri()` and `unified()` without any config change. Using Sätteri requires Astro 7.2.4 or later.

--- a/.changeset/satteri-support.md
+++ b/.changeset/satteri-support.md
@@ -1,0 +1,5 @@
+---
+'astro-auto-import': minor
+---
+
+Adds support for the Sätteri Markdown processor, which is Astro 7’s default. Auto imports now work with both `satteri()` and `unified()` without any config change.

--- a/.changeset/satteri-support.md
+++ b/.changeset/satteri-support.md
@@ -2,4 +2,6 @@
 'astro-auto-import': minor
 ---
 
-Adds support for the Sätteri Markdown processor, which is Astro 7’s default. Auto imports now work with both `satteri()` and `unified()` without any config change. Using Sätteri requires Astro 7.2.4 or later.
+Adds support for the Sätteri Markdown processor, which is Astro 7’s default. 
+
+**⚠️ BREAKING CHANGE:** Drops support for versions of Astro lower than 7.2.4.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         astro: [^5, ^6, ^7]
+        processor: [default]
+        include:
+          - os: ubuntu-latest
+            astro: ^7
+            processor: unified
+          - os: windows-latest
+            astro: ^7
+            processor: unified
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -51,3 +59,5 @@ jobs:
 
       - name: Test
         run: pnpm t
+        env:
+          MARKDOWN_PROCESSOR: ${{ matrix.processor }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        astro: [^5, ^6, ^7]
-        processor: [default]
-        include:
-          - os: ubuntu-latest
-            astro: ^7
-            processor: unified
-          - os: windows-latest
-            astro: ^7
-            processor: unified
+        astro: [^7]
+        processor: [default, unified]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -51,10 +44,7 @@ jobs:
         working-directory: packages/astro-auto-import
       - run: pnpm i astro@${{ matrix.astro }} @astrojs/mdx@${{ env.MDX_VERSION }}
         env:
-          MDX_VERSION: ${{ matrix.astro == '^5' && '^4' || matrix.astro == '^6' && '^5' || '^7' }}
-        working-directory: demo
-      - if: matrix.astro == '^5'
-        run: pnpm un @astrojs/markdown-remark
+          MDX_VERSION: "^7"
         working-directory: demo
 
       - name: Test

--- a/demo/astro.config.mjs
+++ b/demo/astro.config.mjs
@@ -2,16 +2,14 @@ import { defineConfig } from 'astro/config';
 import AutoImport from 'astro-auto-import';
 import mdx from '@astrojs/mdx';
 
-// Astro Markdown configuration. The unified processor is loaded dynamically to support testing
-// against Astro 5 in CI where a custom processor is not available. Set `MARKDOWN_PROCESSOR` to
-// `satteri` to test against Astro 7’s default processor instead.
+// Astro Markdown configuration.
+// Use each Astro version’s default processor unless CI opts into unified.
+// The import is dynamic because CI uninstalls the package on the Astro 5 leg.
 /** @type {import('astro').AstroUserConfig['markdown']} */
 const markdown = {};
-if (process.env.MARKDOWN_PROCESSOR !== 'satteri') {
-  try {
-    const { unified } = await import('@astrojs/markdown-remark');
-    markdown.processor = unified();
-  } catch (e) {}
+if (process.env.MARKDOWN_PROCESSOR === 'unified') {
+  const { unified } = await import('@astrojs/markdown-remark');
+  markdown.processor = unified();
 }
 
 // https://astro.build/config

--- a/demo/astro.config.mjs
+++ b/demo/astro.config.mjs
@@ -3,13 +3,16 @@ import AutoImport from 'astro-auto-import';
 import mdx from '@astrojs/mdx';
 
 // Astro Markdown configuration. The unified processor is loaded dynamically to support testing
-// against Astro 5 in CI where a custom processor is not available.
+// against Astro 5 in CI where a custom processor is not available. Set `MARKDOWN_PROCESSOR` to
+// `satteri` to test against Astro 7’s default processor instead.
 /** @type {import('astro').AstroUserConfig['markdown']} */
 const markdown = {};
-try {
-  const { unified } = await import('@astrojs/markdown-remark');
-  markdown.processor = unified();
-} catch (e) {}
+if (process.env.MARKDOWN_PROCESSOR !== 'satteri') {
+  try {
+    const { unified } = await import('@astrojs/markdown-remark');
+    markdown.processor = unified();
+  } catch (e) {}
+}
 
 // https://astro.build/config
 export default defineConfig({

--- a/demo/package.json
+++ b/demo/package.json
@@ -9,9 +9,9 @@
     "preview": "astro preview"
   },
   "devDependencies": {
-    "@astrojs/markdown-remark": "^7.2.2",
+    "@astrojs/markdown-remark": "^7.2.4",
     "@astrojs/mdx": "^7.0.5",
-    "astro": "^7.2.2",
+    "astro": "^7.2.4",
     "astro-auto-import": "workspace:*",
     "astro-embed": "^0.13.1"
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^1.0.0",
     "@changesets/cli": "^3.0.0",
-    "astro": "^7.2.2",
+    "astro": "^7.2.4",
     "tsm": "^2.3.0",
     "typescript": "^7.0.2",
     "uvu": "^0.5.6"

--- a/packages/astro-auto-import/README.md
+++ b/packages/astro-auto-import/README.md
@@ -14,6 +14,8 @@ If you aren’t already using MDX, you’ll need to add it too:
 npx astro add mdx
 ```
 
+Auto imports work with both of Astro’s Markdown processors. If you use [Sätteri](https://github.com/bruits/satteri), Astro 7’s default, you’ll need Astro 7.2.4 or later: earlier Astro 7 releases ship a Sätteri version without the plugin hook this integration uses.
+
 ## Usage
 
 Import the integration and add it to your `astro.config.*` file:

--- a/packages/astro-auto-import/README.md
+++ b/packages/astro-auto-import/README.md
@@ -14,7 +14,7 @@ If you aren’t already using MDX, you’ll need to add it too:
 npx astro add mdx
 ```
 
-Auto imports work with both of Astro’s Markdown processors. If you use [Sätteri](https://github.com/bruits/satteri), Astro 7’s default, you’ll need Astro 7.2.4 or later: earlier Astro 7 releases ship a Sätteri version without the plugin hook this integration uses.
+`astro-auto-import` supports both of Astro’s official [Markdown processors](https://docs.astro.build/en/guides/markdown-content/#markdown-processors), Sätteri and Unified. Support for Sätteri requires Astro v7.2.4 or later.
 
 ## Usage
 

--- a/packages/astro-auto-import/package.json
+++ b/packages/astro-auto-import/package.json
@@ -32,7 +32,7 @@
   ],
   "devDependencies": {
     "@types/node": "^20.19.43",
-    "astro": "^7.2.2",
+    "astro": "^7.2.4",
     "mdast-util-mdx": "^3.0.0",
     "satteri": "^0.10.5",
     "typescript": "^7.0.2",

--- a/packages/astro-auto-import/package.json
+++ b/packages/astro-auto-import/package.json
@@ -42,9 +42,6 @@
     "acorn": "^8.18.0"
   },
   "peerDependencies": {
-    "astro": "^5.0.0 || ^6.0.0 || ^7.0.0"
-  },
-  "engines": {
-    "node": ">=20.0.0"
+    "astro": "^7.2.4"
   }
 }

--- a/packages/astro-auto-import/package.json
+++ b/packages/astro-auto-import/package.json
@@ -34,6 +34,7 @@
     "@types/node": "^20.19.43",
     "astro": "^7.2.2",
     "mdast-util-mdx": "^3.0.0",
+    "satteri": "^0.10.5",
     "typescript": "^7.0.2",
     "vfile": "^6.0.3"
   },

--- a/packages/astro-auto-import/src/index.ts
+++ b/packages/astro-auto-import/src/index.ts
@@ -171,15 +171,14 @@ export default function AutoImport(integrationConfig: AutoImportConfig): AstroIn
         }
 
         // Add a remark plugin to inject imports into `.mdx`.
+        const remarkPlugin = generateRemarkPlugin(integrationConfig.imports);
         if (processor?.name === 'unified') {
           // Since Astro 7, adding the plugin this way avoids a warning about using the deprecated
           // `markdown.remarkPlugins` config.
-          processor.options.remarkPlugins.push(generateRemarkPlugin(integrationConfig.imports));
+          processor.options.remarkPlugins.push(remarkPlugin);
         } else {
           // For older versions of Astro, we use the `markdown.remarkPlugins` config instead.
-          updateConfig({
-            markdown: { remarkPlugins: [generateRemarkPlugin(integrationConfig.imports)] },
-          });
+          updateConfig({ markdown: { remarkPlugins: [remarkPlugin] } });
         }
       },
     },

--- a/packages/astro-auto-import/src/index.ts
+++ b/packages/astro-auto-import/src/index.ts
@@ -153,33 +153,28 @@ export default function AutoImport(integrationConfig: AutoImportConfig): AstroIn
           return;
         }
 
-        if (processor && processor.name !== 'unified') {
-          throw new Error(
-            '[auto-import] ⚠️ Found incompatible Markdown processor.\n' +
-              '              Only the unified and Sätteri processors are supported.\n' +
-              '              See https://docs.astro.build/en/guides/markdown-content/#markdown-processors',
-          );
-        }
-
-        // Check MDX integration is initialized after auto-import.
-        if (mdxIndex < thisIndex) {
-          console.warn(
-            '[auto-import] ⚠️ @astrojs/mdx initialized BEFORE astro-auto-import.\n' +
-              '              Auto imports in .mdx files won’t work!\n' +
-              '              Move the MDX integration after auto-import in your integrations array in astro.config.',
-          );
-        }
-
         // Add a remark plugin to inject imports into `.mdx`.
-        const remarkPlugin = generateRemarkPlugin(integrationConfig.imports);
         if (processor?.name === 'unified') {
-          // Since Astro 7, adding the plugin this way avoids a warning about using the deprecated
-          // `markdown.remarkPlugins` config.
-          processor.options.remarkPlugins.push(remarkPlugin);
-        } else {
-          // For older versions of Astro, we use the `markdown.remarkPlugins` config instead.
-          updateConfig({ markdown: { remarkPlugins: [remarkPlugin] } });
+          // Check MDX integration is initialized after auto-import.
+          if (mdxIndex < thisIndex) {
+            console.warn(
+              '[auto-import] ⚠️ @astrojs/mdx initialized BEFORE astro-auto-import.\n' +
+                '              Auto imports in .mdx files won’t work!\n' +
+                '              Move the MDX integration after auto-import in your integrations array in astro.config.',
+            );
+          }
+
+          processor.options.remarkPlugins.push(generateRemarkPlugin(integrationConfig.imports));
+
+          return;
         }
+
+        // If we reach this point, the Markdown processor is not supported.
+        throw new Error(
+          '[auto-import] ⚠️ Found incompatible Markdown processor.\n' +
+            '              Only the unified and Sätteri processors are supported.\n' +
+            '              See https://docs.astro.build/en/guides/markdown-content/#markdown-processors',
+        );
       },
     },
   };

--- a/packages/astro-auto-import/src/index.ts
+++ b/packages/astro-auto-import/src/index.ts
@@ -1,5 +1,5 @@
 import { parse as parseJs } from 'acorn';
-import type { AstroIntegration } from 'astro';
+import type { AstroConfig, AstroIntegration } from 'astro';
 import type { MdxjsEsm } from 'mdast-util-mdx';
 import { parse, resolve } from 'node:path';
 import type { MdastPluginDefinition } from 'satteri';
@@ -19,9 +19,14 @@ interface AutoImportConfig {
   imports: ImportsConfig;
 }
 
-/** Astro 5 has no `markdown.processor`, so read it structurally instead of from Astro’s types. */
+/**
+ * A custom type for the Markdown configuration that reflects that the processor config can vary
+ * from project to project and between Astro versions.
+ */
 interface MarkdownConfig {
-  processor?: { name: string; options: { mdastPlugins: MdastPluginDefinition[] } };
+  processor?:
+    | { name: 'satteri'; options: { mdastPlugins: MdastPluginDefinition[] } }
+    | { name: 'unified'; options: { remarkPlugins: AstroConfig['markdown']['remarkPlugins'] } };
 }
 
 /**
@@ -116,6 +121,19 @@ function generateSatteriPlugin(config: ImportsConfig): MdastPluginDefinition {
   };
 }
 
+/** Generate a remark plugin that injects a block of imports based on user config. */
+function generateRemarkPlugin(config: ImportsConfig) {
+  const importsNode = generateImportsNode(config);
+
+  return function rehypeInjectMdxImports() {
+    return function injectMdxImports(tree: { children: any[] }, vfile: VFile) {
+      if (!vfile.basename?.endsWith('.md')) {
+        tree.children.unshift(importsNode);
+      }
+    };
+  };
+}
+
 export default function AutoImport(integrationConfig: AutoImportConfig): AstroIntegration {
   return {
     name: 'auto-import',
@@ -153,21 +171,16 @@ export default function AutoImport(integrationConfig: AutoImportConfig): AstroIn
         }
 
         // Add a remark plugin to inject imports into `.mdx`.
-        const importsNode = generateImportsNode(integrationConfig.imports);
-
-        updateConfig({
-          markdown: {
-            remarkPlugins: [
-              function rehypeInjectMdxImports() {
-                return function injectMdxImports(tree: { children: any[] }, vfile: VFile) {
-                  if (!vfile.basename?.endsWith('.md')) {
-                    tree.children.unshift(importsNode);
-                  }
-                };
-              },
-            ],
-          },
-        });
+        if (processor?.name === 'unified') {
+          // Since Astro 7, adding the plugin this way avoids a warning about using the deprecated
+          // `markdown.remarkPlugins` config.
+          processor.options.remarkPlugins.push(generateRemarkPlugin(integrationConfig.imports));
+        } else {
+          // For older versions of Astro, we use the `markdown.remarkPlugins` config instead.
+          updateConfig({
+            markdown: { remarkPlugins: [generateRemarkPlugin(integrationConfig.imports)] },
+          });
+        }
       },
     },
   };

--- a/packages/astro-auto-import/src/index.ts
+++ b/packages/astro-auto-import/src/index.ts
@@ -2,6 +2,7 @@ import { parse as parseJs } from 'acorn';
 import type { AstroIntegration } from 'astro';
 import type { MdxjsEsm } from 'mdast-util-mdx';
 import { parse, resolve } from 'node:path';
+import type { MdastPluginDefinition } from 'satteri';
 import type { VFile } from 'vfile';
 
 const resolveModulePath = (path: string) => {
@@ -16,6 +17,11 @@ type ImportsConfig = (string | Record<string, string | NamedImportConfig[]>)[];
 
 interface AutoImportConfig {
   imports: ImportsConfig;
+}
+
+/** Astro 5 has no `markdown.processor`, so read it structurally instead of from Astro’s types. */
+interface MarkdownConfig {
+  processor?: { name: string; options: { mdastPlugins: MdastPluginDefinition[] } };
 }
 
 /**
@@ -91,15 +97,54 @@ function generateImportsNode(config: ImportsConfig): MdxjsEsm {
   };
 }
 
+/** Get a Sätteri mdast plugin that injects a block of imports based on user config. */
+function generateSatteriPlugin(config: ImportsConfig): MdastPluginDefinition {
+  // Sätteri parses the import statements itself, so no estree is needed.
+  const value = processImportsConfig(config).join('\n');
+  return {
+    name: 'auto-import',
+    before(root, ctx) {
+      // Plugins also run for `.md`, which can’t use ESM imports.
+      if (ctx.sourceFormat !== 'mdx') return;
+      // Imports go after frontmatter, which Sätteri parses as a root child.
+      const firstBlock = root.children.find(
+        (child) => child.type !== 'yaml' && child.type !== 'toml',
+      );
+      if (!firstBlock) return;
+      ctx.insertBefore(firstBlock, { type: 'mdxjsEsm', value });
+    },
+  };
+}
+
 export default function AutoImport(integrationConfig: AutoImportConfig): AstroIntegration {
   return {
     name: 'auto-import',
     hooks: {
       'astro:config:setup': ({ config, updateConfig }) => {
-        // Check MDX integration is initialized after auto-import.
-        const mdxIndex = config.integrations.findIndex((i) => i.name === '@astrojs/mdx');
         const thisIndex = config.integrations.findIndex((i) => i.name === 'auto-import');
-        if (mdxIndex >= 0 && mdxIndex < thisIndex) {
+        const mdxIndex = config.integrations.findIndex((i) => i.name === '@astrojs/mdx');
+
+        // Skip adding a Markdown plug-in if MDX is not being used.
+        if (mdxIndex === -1) return;
+
+        const processor = (config.markdown as MarkdownConfig | undefined)?.processor;
+
+        // Sätteri reads `processor.options` lazily, so integration order doesn’t matter here.
+        if (processor?.name === 'satteri') {
+          processor.options.mdastPlugins.push(generateSatteriPlugin(integrationConfig.imports));
+          return;
+        }
+
+        if (processor && processor.name !== 'unified') {
+          throw new Error(
+            '[auto-import] ⚠️ Found incompatible Markdown processor.\n' +
+              '              Only the unified and Sätteri processors are supported.\n' +
+              '              See https://docs.astro.build/en/guides/markdown-content/#markdown-processors',
+          );
+        }
+
+        // Check MDX integration is initialized after auto-import.
+        if (mdxIndex < thisIndex) {
           console.warn(
             '[auto-import] ⚠️ @astrojs/mdx initialized BEFORE astro-auto-import.\n' +
               '              Auto imports in .mdx files won’t work!\n' +
@@ -107,20 +152,8 @@ export default function AutoImport(integrationConfig: AutoImportConfig): AstroIn
           );
         }
 
-        // Skip adding MDX plug-in if MDX is not being used.
-        if (mdxIndex === -1) return;
-
         // Add a remark plugin to inject imports into `.mdx`.
         const importsNode = generateImportsNode(integrationConfig.imports);
-
-        // @ts-ignore — When building against Astro v5, `config.markdown.processor` is not available.
-        if (config.markdown?.processor && config.markdown.processor.name !== 'unified') {
-          throw new Error(
-            '[auto-import] ⚠️ Found incompatible Markdown processor.\n' +
-              '              Currently only the unified processor is supported.\n' +
-              '              See https://docs.astro.build/en/guides/markdown-content/#switching-to-the-unified-processor',
-          );
-        }
 
         updateConfig({
           markdown: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       mdast-util-mdx:
         specifier: ^3.0.0
         version: 3.0.0
+      satteri:
+        specifier: ^0.10.5
+        version: 0.10.5
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -242,9 +245,19 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
+  '@bruits/satteri-darwin-arm64@0.10.5':
+    resolution: {integrity: sha512-27KTVl4TJkVahMy/ohyA7qd4938G5UNneFUz/PsScYfpIhj0IVAS23mpcJXdPF44sa6nva198lmV/cKIb2YPyA==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@bruits/satteri-darwin-arm64@0.9.5':
     resolution: {integrity: sha512-iw4nZgx9v30lWo/MTngQqi1pI78KI0DnkSm+lVJGYdmPLgAyDNJigVhpG42/Iq55A6c1Ll8q66ljyyRiQUxwow==}
     cpu: [arm64]
+    os: [darwin]
+
+  '@bruits/satteri-darwin-x64@0.10.5':
+    resolution: {integrity: sha512-IjnLe3nKspq6qaeqGgjT7MT8VrTV74yWRlaag7ZdNsI8TDAYZ0iPxMCo+9KQZHUk5EyVB+reBI/PFWL5KuFw9Q==}
+    cpu: [x64]
     os: [darwin]
 
   '@bruits/satteri-darwin-x64@0.9.5':
@@ -252,11 +265,23 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@bruits/satteri-linux-arm64-gnu@0.10.5':
+    resolution: {integrity: sha512-glkYXZCJywjP13v67eAyAMSJdF+ncvEbYvgi/wOtffL9tQ27lr/zsyzUfgs+ovjJ9d8JNQKiXeiArJcX8PJL9w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@bruits/satteri-linux-arm64-gnu@0.9.5':
     resolution: {integrity: sha512-u51id17uJwNEMK9nBlICsq6U31c+XVqQueVBkwRIzZG+gMpS8TOJctt5h5Wz33Z8xnMdTd+adtACVz0yHgGuOA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
+
+  '@bruits/satteri-linux-arm64-musl@0.10.5':
+    resolution: {integrity: sha512-yWdgG1g17Nh2QyGVlFUxGRa3FEFwiMcpZEyMNWkbM3deC94cmVc+/i9OuyFpdKuWo3GkgoCtYVOoxk1uCnCZIA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
   '@bruits/satteri-linux-arm64-musl@0.9.5':
     resolution: {integrity: sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==}
@@ -264,11 +289,23 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@bruits/satteri-linux-x64-gnu@0.10.5':
+    resolution: {integrity: sha512-FVaLoPT1fBgGl0J+AYebyyXJYBachGl8Oyyrf1lye4RTqCB4S0Gwkj1uM9RJyThUOvx5VUmAT1CnNh1SFHA+kw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@bruits/satteri-linux-x64-gnu@0.9.5':
     resolution: {integrity: sha512-F3uO8uFp3pAP5ZGXttwvh57GS7s0lL953tnNdyI2gRyP4kOOkp6pyGojNJzCjkDvWI2Cvb9iNrKok3aqQPauAw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
+
+  '@bruits/satteri-linux-x64-musl@0.10.5':
+    resolution: {integrity: sha512-EHpVAx2bqW3GINHTKkljtxVfQmVDGWIuwOYOP5YghTj+0PkBa2o8oKPRtQ9Kbsr1Fye8jtUcDjhwj2jMNugZKg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   '@bruits/satteri-linux-x64-musl@0.9.5':
     resolution: {integrity: sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==}
@@ -276,14 +313,29 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@bruits/satteri-wasm32-wasi@0.10.5':
+    resolution: {integrity: sha512-ypz8c/Zmipxp4IoeDa228Gstv6TLzVmNs3yC6wKCoNSOjx1iwpgzu87Y3hTkXFdwChVGU85qeUDuOIarGUZQLw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
   '@bruits/satteri-wasm32-wasi@0.9.5':
     resolution: {integrity: sha512-zauAuMwfPnKPUkd4AFixRFpXdgKwP2mKgxrIIo2gJzW0/ZneF9dbHnLkojSpaBnCCp7VUL1hIi5WWZvB1CqmAQ==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
+  '@bruits/satteri-win32-arm64-msvc@0.10.5':
+    resolution: {integrity: sha512-siTV88nb0LRqNpkL2gXboqCwVdq95sLtzMHS1/3eONV2gLbB3NAK46wmSMvCO/yquBvI2lvaFIfd8P12ecsxBw==}
+    cpu: [arm64]
+    os: [win32]
+
   '@bruits/satteri-win32-arm64-msvc@0.9.5':
     resolution: {integrity: sha512-SrfE7NEsgZjBvU3c+RR6oQRu0ToXY5uVJEbieXEF0YTctIV2zAVlbaMjWLts074QCgh3a+XHWkR/lWh2VH2LUg==}
     cpu: [arm64]
+    os: [win32]
+
+  '@bruits/satteri-win32-x64-msvc@0.10.5':
+    resolution: {integrity: sha512-C3IfPvfvMXmlzBxaMPKFS1XiuV9pu2mC7YqkPk7PSvTgPZ8gbdASIpHpztDLvTTQjqZ0z1Ol8tK5X+V6XXC0wQ==}
+    cpu: [x64]
     os: [win32]
 
   '@bruits/satteri-win32-x64-msvc@0.9.5':
@@ -738,6 +790,13 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
       '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
+
+  '@napi-rs/wasm-runtime@1.2.3':
+    resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.4
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.4
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -2047,6 +2106,9 @@ packages:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
 
+  satteri@0.10.5:
+    resolution: {integrity: sha512-Ao1LKpAEa9Wdg0otgbVKViZHEq9ebdXe4DMrp3s9vQAU0HNIuHnFEuMuOcm0ZIXyV0Yzxj91NvhLpvXZJO/5ZQ==}
+
   satteri@0.9.5:
     resolution: {integrity: sha512-ZuWVl+vnM64y+/TtX8Kosv2c00W+hLQiiwnEL6H0UKVVrxFqMw4D2CJHHQaouVd89OAhtBBfjWLqhKi3TVUV4w==}
 
@@ -2599,22 +2661,47 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@bruits/satteri-darwin-arm64@0.10.5':
+    optional: true
+
   '@bruits/satteri-darwin-arm64@0.9.5':
+    optional: true
+
+  '@bruits/satteri-darwin-x64@0.10.5':
     optional: true
 
   '@bruits/satteri-darwin-x64@0.9.5':
     optional: true
 
+  '@bruits/satteri-linux-arm64-gnu@0.10.5':
+    optional: true
+
   '@bruits/satteri-linux-arm64-gnu@0.9.5':
+    optional: true
+
+  '@bruits/satteri-linux-arm64-musl@0.10.5':
     optional: true
 
   '@bruits/satteri-linux-arm64-musl@0.9.5':
     optional: true
 
+  '@bruits/satteri-linux-x64-gnu@0.10.5':
+    optional: true
+
   '@bruits/satteri-linux-x64-gnu@0.9.5':
     optional: true
 
+  '@bruits/satteri-linux-x64-musl@0.10.5':
+    optional: true
+
   '@bruits/satteri-linux-x64-musl@0.9.5':
+    optional: true
+
+  '@bruits/satteri-wasm32-wasi@0.10.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
   '@bruits/satteri-wasm32-wasi@0.9.5':
@@ -2624,7 +2711,13 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
+  '@bruits/satteri-win32-arm64-msvc@0.10.5':
+    optional: true
+
   '@bruits/satteri-win32-arm64-msvc@0.9.5':
+    optional: true
+
+  '@bruits/satteri-win32-x64-msvc@0.10.5':
     optional: true
 
   '@bruits/satteri-win32-x64-msvc@0.9.5':
@@ -3029,6 +3122,13 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -4677,6 +4777,23 @@ snapshots:
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
+
+  satteri@0.10.5:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+    optionalDependencies:
+      '@bruits/satteri-darwin-arm64': 0.10.5
+      '@bruits/satteri-darwin-x64': 0.10.5
+      '@bruits/satteri-linux-arm64-gnu': 0.10.5
+      '@bruits/satteri-linux-arm64-musl': 0.10.5
+      '@bruits/satteri-linux-x64-gnu': 0.10.5
+      '@bruits/satteri-linux-x64-musl': 0.10.5
+      '@bruits/satteri-wasm32-wasi': 0.10.5
+      '@bruits/satteri-win32-arm64-msvc': 0.10.5
+      '@bruits/satteri-win32-x64-msvc': 0.10.5
 
   satteri@0.9.5:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.1
       astro:
-        specifier: ^7.2.2
-        version: 7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0)
+        specifier: ^7.2.4
+        version: 7.2.4(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0)
       tsm:
         specifier: ^2.3.0
         version: 2.3.0
@@ -30,20 +30,20 @@ importers:
   demo:
     devDependencies:
       '@astrojs/markdown-remark':
-        specifier: ^7.2.2
-        version: 7.2.2
+        specifier: ^7.2.4
+        version: 7.2.4
       '@astrojs/mdx':
         specifier: ^7.0.5
-        version: 7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0))
+        version: 7.0.5(@astrojs/markdown-satteri@0.3.7)(astro@7.2.4(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0))
       astro:
-        specifier: ^7.2.2
-        version: 7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0)
+        specifier: ^7.2.4
+        version: 7.2.4(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0)
       astro-auto-import:
         specifier: workspace:*
         version: link:../packages/astro-auto-import
       astro-embed:
         specifier: ^0.13.1
-        version: 0.13.1(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0))(typescript@7.0.2)
+        version: 0.13.1(astro@7.2.4(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0))(typescript@7.0.2)
 
   packages/astro-auto-import:
     dependencies:
@@ -55,8 +55,8 @@ importers:
         specifier: ^20.19.43
         version: 20.19.43
       astro:
-        specifier: ^7.2.2
-        version: 7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0)
+        specifier: ^7.2.4
+        version: 7.2.4(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0)
       mdast-util-mdx:
         specifier: ^3.0.0
         version: 3.0.0
@@ -172,11 +172,17 @@ packages:
   '@astrojs/internal-helpers@0.10.2':
     resolution: {integrity: sha512-yt7fMgPYqSM4Tmr+taTW6Per+hjJ8Pk6lA1PAcDyqzOt8HzJ6Kje5WzCxA2Sd+9wsUW7uhkLeoTMK0cXPwH9rQ==}
 
+  '@astrojs/internal-helpers@0.10.4':
+    resolution: {integrity: sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA==}
+
   '@astrojs/markdown-remark@7.2.2':
     resolution: {integrity: sha512-FGfmK84zSNcrsBd0dl1gXE9JvZYElp8EXQa2jpHVAxG4deGKAp43wspxFupjADJX7MSsMRHwYCnfT6EyVmgeFQ==}
 
-  '@astrojs/markdown-satteri@0.3.5':
-    resolution: {integrity: sha512-CvWVEFAbay7YO+i9SaqDJubipA5ckiVB89QWoMJ5XC0m5CtFg8JwZ7Kau6X9sYY7FZURH0w2l03ISH2jOS/RDQ==}
+  '@astrojs/markdown-remark@7.2.4':
+    resolution: {integrity: sha512-MvspGMynWKAjTe4/lTUdmBPHIFKNVLTCF6UlyWGogTGzNrTvjD+D4n48k7h8swxsEPKHK2TwxkZO7uoaCv1Pow==}
+
+  '@astrojs/markdown-satteri@0.3.7':
+    resolution: {integrity: sha512-NHcHbrKW/opbZnTZQ5nH293BdcK2VV0tjuzI88CLnvy2njiEJVwUQ5KFnYd4NoWgHJCY/I1CyjGWCR4Vv3khXQ==}
 
   '@astrojs/mdx@7.0.5':
     resolution: {integrity: sha512-wEM/HH1RiEntyPVagdiF+yArzfcYLKBB0C1RZspVidKZ97rRMbaqP1Nbl/GR0sJs8zwaceqxRymw8aOKKJRdYw==}
@@ -250,29 +256,13 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@bruits/satteri-darwin-arm64@0.9.5':
-    resolution: {integrity: sha512-iw4nZgx9v30lWo/MTngQqi1pI78KI0DnkSm+lVJGYdmPLgAyDNJigVhpG42/Iq55A6c1Ll8q66ljyyRiQUxwow==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@bruits/satteri-darwin-x64@0.10.5':
     resolution: {integrity: sha512-IjnLe3nKspq6qaeqGgjT7MT8VrTV74yWRlaag7ZdNsI8TDAYZ0iPxMCo+9KQZHUk5EyVB+reBI/PFWL5KuFw9Q==}
     cpu: [x64]
     os: [darwin]
 
-  '@bruits/satteri-darwin-x64@0.9.5':
-    resolution: {integrity: sha512-6T26Z5Kf3cFW2PSlk9p7zT7yVxvuBSiJvYyz9u8KjYwMTqZyIDOj2wDyNpxKV4+6yUVG7rddq2QwvG/8LJA2+Q==}
-    cpu: [x64]
-    os: [darwin]
-
   '@bruits/satteri-linux-arm64-gnu@0.10.5':
     resolution: {integrity: sha512-glkYXZCJywjP13v67eAyAMSJdF+ncvEbYvgi/wOtffL9tQ27lr/zsyzUfgs+ovjJ9d8JNQKiXeiArJcX8PJL9w==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@bruits/satteri-linux-arm64-gnu@0.9.5':
-    resolution: {integrity: sha512-u51id17uJwNEMK9nBlICsq6U31c+XVqQueVBkwRIzZG+gMpS8TOJctt5h5Wz33Z8xnMdTd+adtACVz0yHgGuOA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -283,20 +273,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@bruits/satteri-linux-arm64-musl@0.9.5':
-    resolution: {integrity: sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@bruits/satteri-linux-x64-gnu@0.10.5':
     resolution: {integrity: sha512-FVaLoPT1fBgGl0J+AYebyyXJYBachGl8Oyyrf1lye4RTqCB4S0Gwkj1uM9RJyThUOvx5VUmAT1CnNh1SFHA+kw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@bruits/satteri-linux-x64-gnu@0.9.5':
-    resolution: {integrity: sha512-F3uO8uFp3pAP5ZGXttwvh57GS7s0lL953tnNdyI2gRyP4kOOkp6pyGojNJzCjkDvWI2Cvb9iNrKok3aqQPauAw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -307,19 +285,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@bruits/satteri-linux-x64-musl@0.9.5':
-    resolution: {integrity: sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@bruits/satteri-wasm32-wasi@0.10.5':
     resolution: {integrity: sha512-ypz8c/Zmipxp4IoeDa228Gstv6TLzVmNs3yC6wKCoNSOjx1iwpgzu87Y3hTkXFdwChVGU85qeUDuOIarGUZQLw==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
-  '@bruits/satteri-wasm32-wasi@0.9.5':
-    resolution: {integrity: sha512-zauAuMwfPnKPUkd4AFixRFpXdgKwP2mKgxrIIo2gJzW0/ZneF9dbHnLkojSpaBnCCp7VUL1hIi5WWZvB1CqmAQ==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
@@ -328,18 +295,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@bruits/satteri-win32-arm64-msvc@0.9.5':
-    resolution: {integrity: sha512-SrfE7NEsgZjBvU3c+RR6oQRu0ToXY5uVJEbieXEF0YTctIV2zAVlbaMjWLts074QCgh3a+XHWkR/lWh2VH2LUg==}
-    cpu: [arm64]
-    os: [win32]
-
   '@bruits/satteri-win32-x64-msvc@0.10.5':
     resolution: {integrity: sha512-C3IfPvfvMXmlzBxaMPKFS1XiuV9pu2mC7YqkPk7PSvTgPZ8gbdASIpHpztDLvTTQjqZ0z1Ol8tK5X+V6XXC0wQ==}
-    cpu: [x64]
-    os: [win32]
-
-  '@bruits/satteri-win32-x64-msvc@0.9.5':
-    resolution: {integrity: sha512-5Kw9ZAtTGS8WHizyn+CJhjjfIQrw+7jcZodpmpXJjefnO15M8UexIi6JR2E5thyvsmHyhL6ZDDMUNR4bKJPd4g==}
     cpu: [x64]
     os: [win32]
 
@@ -784,13 +741,6 @@ packages:
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
-  '@napi-rs/wasm-runtime@1.2.2':
-    resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
-      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
-
   '@napi-rs/wasm-runtime@1.2.3':
     resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
@@ -1152,12 +1102,12 @@ packages:
     peerDependencies:
       astro: ^5.0.0 || ^6.0.0-alpha || ^7.0.0
 
-  astro@7.2.2:
-    resolution: {integrity: sha512-OvLWCpXpb43lVYcWzSBJ0sk44qcEYYRZCjadtalLfAwb2RaC3P/zT+blZykBw/o6suw6sQQkn00ugN36akD8Mw==}
+  astro@7.2.4:
+    resolution: {integrity: sha512-+cuLsBns2wwUHI9a10xZMbjrF91m7+QNwqTVeljTx0B8Lf+8h0LgVGjdVIL2FALDKD2I565lczeeS3BFC+KdZg==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
     peerDependencies:
-      '@astrojs/markdown-remark': 7.2.2
+      '@astrojs/markdown-remark': 7.2.4
     peerDependenciesMeta:
       '@astrojs/markdown-remark':
         optional: true
@@ -2109,9 +2059,6 @@ packages:
   satteri@0.10.5:
     resolution: {integrity: sha512-Ao1LKpAEa9Wdg0otgbVKViZHEq9ebdXe4DMrp3s9vQAU0HNIuHnFEuMuOcm0ZIXyV0Yzxj91NvhLpvXZJO/5ZQ==}
 
-  satteri@0.9.5:
-    resolution: {integrity: sha512-ZuWVl+vnM64y+/TtX8Kosv2c00W+hLQiiwnEL6H0UKVVrxFqMw4D2CJHHQaouVd89OAhtBBfjWLqhKi3TVUV4w==}
-
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
@@ -2220,14 +2167,18 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
+
   unicode-segmenter@0.14.5:
     resolution: {integrity: sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
-  unifont@0.7.4:
-    resolution: {integrity: sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==}
+  unifont@0.7.5:
+    resolution: {integrity: sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==}
 
   unist-util-find-after@5.0.0:
     resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
@@ -2442,7 +2393,7 @@ snapshots:
     dependencies:
       '@astro-community/astro-embed-utils': 0.2.0
 
-  '@astro-community/astro-embed-integration@0.12.1(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0))(typescript@7.0.2)':
+  '@astro-community/astro-embed-integration@0.12.1(astro@7.2.4(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0))(typescript@7.0.2)':
     dependencies:
       '@astro-community/astro-embed-bluesky': 0.2.3(typescript@7.0.2)
       '@astro-community/astro-embed-gist': 0.1.0
@@ -2452,8 +2403,8 @@ snapshots:
       '@astro-community/astro-embed-vimeo': 0.3.12
       '@astro-community/astro-embed-youtube': 0.5.10
       '@types/unist': 3.0.3
-      astro: 7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0)
-      astro-auto-import: 0.5.1(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0))
+      astro: 7.2.4(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0)
+      astro-auto-import: 0.5.1(astro@7.2.4(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0))
       unist-util-select: 5.1.0
     transitivePeerDependencies:
       - typescript
@@ -2502,7 +2453,7 @@ snapshots:
 
   '@astrojs/compiler-binding-wasm32-wasi@0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -2547,6 +2498,17 @@ snapshots:
       smol-toml: 1.7.0
       unified: 11.0.5
 
+  '@astrojs/internal-helpers@0.10.4':
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      js-yaml: 4.3.0
+      picomatch: 4.0.5
+      retext-smartypants: 6.2.0
+      shiki: 4.3.1
+      smol-toml: 1.7.0
+      unified: 11.0.5
+
   '@astrojs/markdown-remark@7.2.2':
     dependencies:
       '@astrojs/internal-helpers': 0.10.2
@@ -2569,21 +2531,42 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/markdown-satteri@0.3.5':
+  '@astrojs/markdown-remark@7.2.4':
     dependencies:
-      '@astrojs/internal-helpers': 0.10.2
+      '@astrojs/internal-helpers': 0.10.4
       '@astrojs/prism': 4.0.2
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
-      satteri: 0.9.5
+      hast-util-to-text: 4.0.2
+      mdast-util-definitions: 6.0.0
+      rehype-raw: 7.0.0
+      rehype-stringify: 10.0.1
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remark-smartypants: 3.0.2
+      unified: 11.0.5
+      unist-util-remove-position: 5.0.0
+      unist-util-visit: 5.1.0
+      unist-util-visit-parents: 6.0.2
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
-  '@astrojs/mdx@7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0))':
+  '@astrojs/markdown-satteri@0.3.7':
+    dependencies:
+      '@astrojs/internal-helpers': 0.10.4
+      '@astrojs/prism': 4.0.2
+      github-slugger: 2.0.0
+      satteri: 0.10.5
+
+  '@astrojs/mdx@7.0.5(@astrojs/markdown-satteri@0.3.7)(astro@7.2.4(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0))':
     dependencies:
       '@astrojs/internal-helpers': 0.10.2
       '@astrojs/markdown-remark': 7.2.2
       '@mdx-js/mdx': 3.1.1
       acorn: 8.18.0
-      astro: 7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0)
+      astro: 7.2.4(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0)
       es-module-lexer: 2.3.1
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -2595,7 +2578,7 @@ snapshots:
       unist-util-visit: 5.1.0
       vfile: 6.0.3
     optionalDependencies:
-      '@astrojs/markdown-satteri': 0.3.5
+      '@astrojs/markdown-satteri': 0.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -2664,37 +2647,19 @@ snapshots:
   '@bruits/satteri-darwin-arm64@0.10.5':
     optional: true
 
-  '@bruits/satteri-darwin-arm64@0.9.5':
-    optional: true
-
   '@bruits/satteri-darwin-x64@0.10.5':
-    optional: true
-
-  '@bruits/satteri-darwin-x64@0.9.5':
     optional: true
 
   '@bruits/satteri-linux-arm64-gnu@0.10.5':
     optional: true
 
-  '@bruits/satteri-linux-arm64-gnu@0.9.5':
-    optional: true
-
   '@bruits/satteri-linux-arm64-musl@0.10.5':
-    optional: true
-
-  '@bruits/satteri-linux-arm64-musl@0.9.5':
     optional: true
 
   '@bruits/satteri-linux-x64-gnu@0.10.5':
     optional: true
 
-  '@bruits/satteri-linux-x64-gnu@0.9.5':
-    optional: true
-
   '@bruits/satteri-linux-x64-musl@0.10.5':
-    optional: true
-
-  '@bruits/satteri-linux-x64-musl@0.9.5':
     optional: true
 
   '@bruits/satteri-wasm32-wasi@0.10.5':
@@ -2704,23 +2669,10 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@bruits/satteri-wasm32-wasi@0.9.5':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-    optional: true
-
   '@bruits/satteri-win32-arm64-msvc@0.10.5':
     optional: true
 
-  '@bruits/satteri-win32-arm64-msvc@0.9.5':
-    optional: true
-
   '@bruits/satteri-win32-x64-msvc@0.10.5':
-    optional: true
-
-  '@bruits/satteri-win32-x64-msvc@0.9.5':
     optional: true
 
   '@capsizecss/unpack@4.0.1':
@@ -3111,24 +3063,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
-  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.2
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
   '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.2
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -3182,7 +3127,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.1.5':
@@ -3363,31 +3308,31 @@ snapshots:
 
   astring@1.8.3: {}
 
-  astro-auto-import@0.5.1(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0)):
+  astro-auto-import@0.5.1(astro@7.2.4(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0)):
     dependencies:
       acorn: 8.18.0
-      astro: 7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0)
+      astro: 7.2.4(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0)
 
-  astro-embed@0.13.1(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0))(typescript@7.0.2):
+  astro-embed@0.13.1(astro@7.2.4(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0))(typescript@7.0.2):
     dependencies:
       '@astro-community/astro-embed-baseline-status': 0.2.2
       '@astro-community/astro-embed-bluesky': 0.2.3(typescript@7.0.2)
       '@astro-community/astro-embed-gist': 0.1.0
-      '@astro-community/astro-embed-integration': 0.12.1(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0))(typescript@7.0.2)
+      '@astro-community/astro-embed-integration': 0.12.1(astro@7.2.4(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0))(typescript@7.0.2)
       '@astro-community/astro-embed-link-preview': 0.3.1
       '@astro-community/astro-embed-mastodon': 0.1.1
       '@astro-community/astro-embed-twitter': 0.5.11
       '@astro-community/astro-embed-vimeo': 0.3.12
       '@astro-community/astro-embed-youtube': 0.5.10
-      astro: 7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0)
+      astro: 7.2.4(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0)
     transitivePeerDependencies:
       - typescript
 
-  astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0):
+  astro@7.2.4(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@20.19.43)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler-rs': 0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
-      '@astrojs/internal-helpers': 0.10.2
-      '@astrojs/markdown-satteri': 0.3.5
+      '@astrojs/internal-helpers': 0.10.4
+      '@astrojs/markdown-satteri': 0.3.7
       '@astrojs/telemetry': 3.3.3
       '@capsizecss/unpack': 4.0.1
       '@clack/prompts': 1.7.0
@@ -3431,7 +3376,7 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       ultrahtml: 1.7.0
-      unifont: 0.7.4
+      unifont: 0.7.5
       unstorage: 1.17.5
       vite: 8.1.5(@types/node@20.19.43)(esbuild@0.28.1)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.1.5(@types/node@20.19.43)(esbuild@0.28.1)(yaml@2.9.0))
@@ -3439,7 +3384,7 @@ snapshots:
       yargs-parser: 22.0.0
       zod: 4.4.3
     optionalDependencies:
-      '@astrojs/markdown-remark': 7.2.2
+      '@astrojs/markdown-remark': 7.2.4
       sharp: 0.35.3(@types/node@20.19.43)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -4795,23 +4740,6 @@ snapshots:
       '@bruits/satteri-win32-arm64-msvc': 0.10.5
       '@bruits/satteri-win32-x64-msvc': 0.10.5
 
-  satteri@0.9.5:
-    dependencies:
-      '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.5
-      '@types/mdast': 4.0.4
-      '@types/unist': 3.0.3
-    optionalDependencies:
-      '@bruits/satteri-darwin-arm64': 0.9.5
-      '@bruits/satteri-darwin-x64': 0.9.5
-      '@bruits/satteri-linux-arm64-gnu': 0.9.5
-      '@bruits/satteri-linux-arm64-musl': 0.9.5
-      '@bruits/satteri-linux-x64-gnu': 0.9.5
-      '@bruits/satteri-linux-x64-musl': 0.9.5
-      '@bruits/satteri-wasm32-wasi': 0.9.5
-      '@bruits/satteri-win32-arm64-msvc': 0.9.5
-      '@bruits/satteri-win32-x64-msvc': 0.9.5
-
   sax@1.6.0: {}
 
   semver@7.8.5: {}
@@ -4953,6 +4881,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@8.10.0: {}
+
   unicode-segmenter@0.14.5: {}
 
   unified@11.0.5:
@@ -4965,11 +4895,11 @@ snapshots:
       trough: 2.1.0
       vfile: 6.0.3
 
-  unifont@0.7.4:
+  unifont@0.7.5:
     dependencies:
       css-tree: 3.2.1
-      ofetch: 1.5.1
       ohash: 2.0.11
+      undici: 8.10.0
 
   unist-util-find-after@5.0.0:
     dependencies:


### PR DESCRIPTION
Sätteri 0.10.5 unblocked this change so here it is!

- Closes the Sätteri half of #153.
- Registers an mdast plugin on `processor.options.mdastPlugins`, sharing processImportsConfig with the unified path.
- The MDX ordering warning is now unified-only as Sätteri reads `processor.options` lazily, so integration order no longer matters.
- Demo can be built against either processor via `MARKDOWN_PROCESSOR=satteri`; CI has no Sätteri path yet, but I could add one if you like!